### PR TITLE
Correct typographical errors in Prime.

### DIFF
--- a/Prime/Little_Office_Prime.tex
+++ b/Prime/Little_Office_Prime.tex
@@ -218,7 +218,7 @@
 	\gresetinitiallines{0}
 	\gregorioscore{memento_rerum_conditor}
 }{
-	1. Remember, Make of all things, 
+	1. Remember, Maker of all things,
 	That once the form of our flesh, 
 	From the Virgin's sacred womb, 
 	Being born, Thou didst assume.
@@ -277,7 +277,7 @@
 	
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spi\textbf{rí}tui \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textbf{ló}rum. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textbf{ló}rum. \textbf{A}men.
 	
 	\end{verses}
 }{
@@ -348,7 +348,7 @@
 	
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spi\textbf{rí}tui \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textbf{ló}rum. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textbf{ló}rum. \textbf{A}men.
 	
 	\end{verses}
 }{
@@ -373,7 +373,7 @@
 	7. Shew us, O Lord, thy mercy:
 	and grant us thy salvation.
 	
-	8. I will hearken what the Lord God shall we within me:
+	8. I will hearken what the Lord God shall say within me:
 	for he will speak peace unto his people:
 	
 	9. Unto his Saints likewise:
@@ -416,7 +416,7 @@
 
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spi\textbf{rí}tui \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textbf{ló}rum. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textbf{ló}rum. \textbf{A}men.
 	
 	\end{verses}
 	
@@ -426,13 +426,13 @@
 	1. Praise the Lord, all ye gentiles:
 	praise him, all ye people.
 	
-	2. For his mercy is confiremd upon us:
+	2. For his mercy is confirmed upon us:
 	and the truth of the Lord endureth forever.
 	
 	3. Glory be to the Father, and to the Son, and to the Holy Spirit:
 	As it was in the beginning, is now, and ever shall be, world without end. Amen.
 	
-	Mary was taken up to heaven: the angels rejoice, and with praises bless The Lord.
+	Mary was taken up to heaven: the angels rejoice, and with praises bless the Lord.
 }
 
 \rubric{\color{red}Proceed to page 15.}
@@ -476,7 +476,7 @@
 	
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spirí\textit{tu}\textit{i} \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
 	
 	\end{verses}
 }{
@@ -546,7 +546,7 @@
 	
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spirí\textit{tu}\textit{i} \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(bow)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
+	\item {\color{red}\textit{(bow)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
 	
 	\end{verses}
 }{
@@ -614,7 +614,7 @@
 
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spirí\textit{tu}\textit{i} \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
 	
 	\end{verses}
 	
@@ -674,7 +674,7 @@
 	
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spirí\textit{tu}\textit{i} \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
 	
 	\end{verses}
 }{
@@ -745,7 +745,7 @@
 	
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spirí\textit{tu}\textit{i} \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
 	
 	\end{verses}
 }{
@@ -813,7 +813,7 @@
 
 	\item {\color{red}\textit{(bow)}} Glória \textbf{Pa}tri, et \textbf{Fí}lio,~* et Spirí\textit{tu}\textit{i} \textbf{Sanc}to.
 	
-	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in sǽcula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
+	\item {\color{red}\textit{(rise)}} Sicut erat in princípio, et \textbf{nunc}, et \textbf{sem}per,~* et in s\'{\ae}cula sæcu\textit{ló}\textit{rum}. \textbf{A}men.
 	
 	\end{verses}
 	
@@ -855,7 +855,7 @@
 	{\color{red}\Vbar.} Domine, exaudi orationem meam.\\
 	{\color{red}\Rbar.} Et clamor meus ad te veniat.
 }{
-	And I took root in an honorable people, and in the portion of my God his inheritance: and my abode is in the full is  in the full assembly of Saints.
+	And I took root in an honorable people, and in the portion of my God his inheritance: and my abode is in the full assembly of Saints.
 	
 	{\color{red}\Rbar.} Thanks be to God.
 	{\color{red}\Vbar.} Vouchsafe that I may praise thee, O sacred Virgin.
@@ -903,7 +903,7 @@
 	{\color{red}\Rbar.} Amen.
 }{
 	Let us pray.
-	O God, who didst vouchsafe to choose the chaste chamber of the blessed Virgin Mary to dwell therein; grant, we bessech thee, that, fortified with her defense, ew may find our joy in taking part in her commemoration. Who livest and reignest with God the Father, in the unity of the Holy Spirit, world without end.
+	O God, who didst vouchsafe to choose the chaste chamber of the blessed Virgin Mary to dwell therein; grant, we beseech thee, that, fortified with her defense, we may find our joy in taking part in her commemoration. Who livest and reignest with God the Father, in the unity of the Holy Spirit, world without end.
 	
 	{\color{red}\Rbar.} Amen.
 }
@@ -934,7 +934,7 @@
 
 \latinenglish{
 	Orémus.
-	Deus, qui salutis æternæ, beatæ Mariæ virginitate foecunda, humano generi præmia præstitisti: {\color{red}\GreDagger}\ tribue, quæsumus; ut ipsam pro nobis intercedere \textit{senti}\textbf{a}mus, per quam meruimus auctorem vitæ suscipere, ~* Dominum nnostrum Jesum Christum, Filium tuum. Qui tecum vivit et regnat in unitate Spiritu Sancti Deus, per omnia s\'{\ae}cula sæculórum.
+	Deus, qui salutis æternæ, beatæ Mariæ virginitate foecunda, humano generi præmia præstitisti: {\color{red}\GreDagger}\ tribue, quæsumus; ut ipsam pro nobis intercedere \textit{senti}\textbf{a}mus, per quam meruimus auctorem vitæ suscipere, ~* Dominum nostrum Jesum Christum, Filium tuum. Qui tecum vivit et regnat in unitate Spiritu Sancti Deus, per omnia s\'{\ae}cula sæculórum.
 	
 	{\color{red}\Rbar.} Amen.
 }{
@@ -959,7 +959,7 @@
 	\gabcsnippet{(c3) <c><sp>V/</sp>.</c> Do(h)mi(h)ne(h) e(h)xau(h)di(h) o(h)ra(h)ti(h)ó(h)nem(h) me(h)am.(f) (::)}
 
 	\gresetinitiallines{0}
-	\gabcsnippet{(c3) <c><sp>R/</sp>.</c> Et(h) cla(h)mor(h) me(h)us(h) ad(h) te(h) vé(h)ni(h)at.(f) (::)}
+	\gabcsnippet{(c3) <c><sp>R/</sp>.</c> Et(h) cla(h)mor(h) me(h)us(h) ad(h) te(h) vé(h)ni(f)at.(f) (::)}
 }{
 	{\color{red}\Vbar.} O Lord, hear my prayer.
 	{\color{red}\Rbar.} And let my cry come unto thee.


### PR DESCRIPTION
This commit fixes some errors that will be obvious in review.
The replacement of `ǽ` with `\'{\ae}` is less obvious; the former character
failed to render in the generated PDF, leaving several instances of `scula` in
the document prepared for printing.