### PR TITLE
Revise tune for hymn Memento.

### DIFF
--- a/common/memento_rerum_conditor.gabc
+++ b/common/memento_rerum_conditor.gabc
@@ -5,4 +5,17 @@ name: Memento rerum Conditor;
 office-part: Marian Hymn;
 %%
 
-(c4)1. Me(h)mé(hg)nto(ed), re(g)ru(hj)m Có(ji)ndi(h)to(i)r, (::) No(i)stri(k) quo(i)d o(ji)li(h)m có(ih)rpo(g)ri(h)s, (:) Sa(k)crá(k)t<i>a</i> a(i)b a(k)lvo(k_l_k_) Vi(j)rgi(i)ni(hiwj/i/h/g)s (;) Na(i)scé(k)ndo(i), fo(ji)rma(h)m sú(ih)mpse(g)ri(h)s (::) 2. Ma(h)ri(hg)a(ed), ma(g)te(hj)r grá(ji)ti(h)æ(i), (;) Du(i)lci(k)s pa(i)re(ji)ns cle(h)mé(ih)nti(g)æ(h), (:) Tu(k) no(k)s a(i)b ho(k)ste(k_l_k_) pró(j)te(i)ge(hiwj/i/h/g), (;) E(i)t mo(k)rti(i)s ho(ji)ra(h) sú(ih)sci(g)pe(h). <c><i><sp>(</sp>bow<sp>)</sp></i></c>(::) 3. Je(h)su(hg), ti(ed)bi(g) si(hj)t gló(ji)ri(h)a(i), (;) Qui(i) na(k)tu(i)s e(ji)s de(h) Vi(ih)rgi(g) ne(h), (;) Cu(k)m Pa(k)tr<i>e</i> e(i)t a(k)lmo(k_l_k_) Spi(j)ri(i)tu(hiwj/i/h/g) (;) I(i)n se(k)mpi(i)té(ji)rna(h) sæ(ih)cu(g)la(h). <c><i><sp>(</sp>rise<sp>)</sp></i></c>(::) A(hih)me(g.h.)n. (::)
+(c4)1. Me(h)mén(h_g)to(ed), re(g)rum(hj) Có(ji)ndi(h)tor,(i.) (;)
+No(hk)stri(k) quo(i)d o(ji)li(h)m có(ih)rpo(g)ris,(h.) (:)
+Sa(k)crá(k)t<i>a</i> a(i)b a(k)lvo(klk) Vi(ji)rgi(hi)nis(ivHG.) (;)
+Na(ji)scé(jk)ndo(i), for(ji)mam(h) sú(ih)mpse(g)ris(h.) (::)
+
+2. Ma(h)ri(h_g)a,(ed) ma(g)te(hj)r grá(ji)ti(h)æ,(i.) (;)
+Du(hk)lci(k)s pa(i)re(ji)ns cle(h)mé(ih)nti(g)æ,(h.) (:)
+Tu(k) no(k)s a(i)b ho(k)ste(klk) pró(ji)te(hi)ge,(ivHG.) (;)
+E(ji)t mor(jk)tis(i) ho(ji)ra(h) sú(ih)sci(g)pe.(h.) <c><i><sp>(</sp>bow<sp>)</sp></i></c>(::)
+3. Je(h)su,(h_g) ti(ed)bi(g) si(hj)t gló(ji)ri(h)a,(i.) (;)
+Qui(hk) na(k)tus(i) e(ji)s de(h) Vir(ih)gi(g)ne,(h.) (:)
+Cu(k)m Pa(k)tr<i>e</i> e(i)t a(k)lmo(klk) Spi(ji)ri(hi)tu(ivHG.) (;)
+In(ji) sem(jk)pi(i)tér(ji)na(h) sæ(ih)cu(g)la.(h.) <c><i><sp>(</sp>rise<sp>)</sp></i></c>(::)
+A(hih)men.(g.h.) (::)


### PR DESCRIPTION
This commit revises the tune for the hymn _Memento rerum Conditor_ to match the
melody typically sang in the Washtenaw area, also represented
[here](https://archive.ccwatershed.org/media/pdfs/15/06/28/22-01-06_0.pdf).

The diff looks more like a re-write because I also revised the source `gabc`
file to break lines with each phrase.